### PR TITLE
Allow specifying buffer sizes in `KernelBuilder`

### DIFF
--- a/examples/vector_add/CMakeLists.txt
+++ b/examples/vector_add/CMakeLists.txt
@@ -3,6 +3,8 @@ cmake_minimum_required(VERSION 3.17)
 set (PROJECT_NAME kernel_launcher_vecadd)
 project(${PROJECT_NAME} LANGUAGES CXX CUDA)
 
+set (CMAKE_CXX_STANDARD 17)
+
 add_executable(${PROJECT_NAME} "${PROJECT_SOURCE_DIR}/main.cu")
 target_link_libraries(${PROJECT_NAME} kernel_launcher)
 

--- a/include/kernel_launcher/arg.h
+++ b/include/kernel_launcher/arg.h
@@ -24,13 +24,13 @@ struct KernelArg {
     ~KernelArg();
 
     template<typename T>
-    static KernelArg for_scalar(T value) {
+    static KernelArg from_scalar(T value) {
         static_assert(sizeof(T) == type_of<T>().size(), "internal error");
         return KernelArg(type_of<T>(), (void*)&value);
     }
 
     template<typename T>
-    static KernelArg for_array(T* value, size_t nelements) {
+    static KernelArg from_array(T* value, size_t nelements) {
         static_assert(sizeof(T) == type_of<T>().size(), "internal error");
         static_assert(sizeof(T*) == type_of<T*>().size(), "internal error");
         return KernelArg(type_of<T*>(), (void*)value, nelements);
@@ -86,7 +86,7 @@ struct IntoKernelArg<
     T,
     typename std::enable_if<std::is_scalar<T>::value>::type> {
     static KernelArg convert(T value) {
-        return KernelArg::for_scalar<T>(value);
+        return KernelArg::from_scalar<T>(value);
     }
 };
 
@@ -95,7 +95,7 @@ struct IntoKernelArg<
     CudaSpan<T>,
     typename std::enable_if<std::is_trivially_copyable<T>::value>::type> {
     static KernelArg convert(CudaSpan<T> s) {
-        return KernelArg::for_array<T>(s.data(), s.size());
+        return KernelArg::from_array<T>(s.data(), s.size());
     }
 };
 

--- a/include/kernel_launcher/arg.h
+++ b/include/kernel_launcher/arg.h
@@ -23,6 +23,9 @@ struct KernelArg {
     KernelArg(const KernelArg&);
     ~KernelArg();
 
+    KernelArg& operator=(const KernelArg&);
+    KernelArg& operator=(KernelArg&&) noexcept;
+
     template<typename T>
     static KernelArg from_scalar(T value) {
         static_assert(sizeof(T) == type_of<T>().size(), "internal error");

--- a/include/kernel_launcher/arg.h
+++ b/include/kernel_launcher/arg.h
@@ -7,7 +7,6 @@
 #include <iostream>
 #include <utility>
 
-#include "kernel_launcher/builder.h"
 #include "kernel_launcher/compiler.h"
 #include "kernel_launcher/config.h"
 
@@ -49,6 +48,7 @@ struct KernelArg {
         return result;
     }
 
+    KernelArg to_array(size_t nelements) const;
     Value to_value() const;
     Value to_value_or_empty() const;
     void assert_type_matches(TypeInfo t) const;

--- a/include/kernel_launcher/builder.h
+++ b/include/kernel_launcher/builder.h
@@ -133,6 +133,55 @@ struct KernelBuilder: ConfigSpace {
     KernelBuilder& argument_processor(ArgumentsProcessor f);
 
     /**
+     * Set the size (in number of elements) for the given argument of this
+     * kernel. For example, the following example sets the length of the buffer
+     * given by the 5th argument (index=4) to the integer value given by
+     * the 1st argument (index=0).
+     *
+     * ```
+     * builder.buffer_size(4, arg0);
+     * ```
+     *
+     * Alternatively, it is recommended to use this function in combination
+     * with the `args` function for more readable variable names. For example,
+     * the following kernel takes three arguments (`n`, `A`, `B`) where the
+     * size of `A` and `B` is given by the variable `n`.
+     *
+     * ```
+     * auto [n, A, B] = args<3>();
+     * builder.buffer_size(A, n);
+     * builder.buffer_size(B, 2 * n);
+     * ```
+     *
+     * @param arg The argument buffer that this size is applied to.
+     * @param len The length of the buffer in number of elements.
+     * @return `this`
+     */
+    KernelBuilder& buffer_size(ArgExpr arg, TypedExpr<size_t> len);
+
+    /**
+     * Short-hand for using `KernelBuilder::buffer_size(...)`. For example,
+     * the following kernel takes three arguments (`n`, `A`, `B`) where the
+     * size of `A` and `B` is given by the expressions `n` and `2 * n`.
+     *
+     * ```
+     * auto [n, A, B] = args<3>();
+     * builder.buffers(A[n], B[2 * n]);
+     * ```
+     *
+     * @param buffers Expressions of type `ArgBuffer`.
+     * @return `this`
+     */
+    template<typename... Ts>
+    KernelBuilder& buffers(Ts... buffers) {
+        for (auto arg : std::array<ArgBuffer, sizeof...(Ts)> {buffers...}) {
+            buffer_size(arg.index, arg.length);
+        }
+
+        return *this;
+    }
+
+    /**
      * Set the block size for this kernel (i.e., number of threads per
      * thread block).
      *

--- a/include/kernel_launcher/expr.h
+++ b/include/kernel_launcher/expr.h
@@ -239,6 +239,11 @@ inline ProblemExpr problem_size(size_t axis = 0) {
     return axis;
 }
 
+struct ArgBuffer {
+    uint8_t index;
+    TypedExpr<size_t> length;
+};
+
 struct ArgExpr: BaseExpr, Variable {
     constexpr ArgExpr(uint8_t i) noexcept : index_(i) {};
     std::string to_string() const override;
@@ -259,6 +264,10 @@ struct ArgExpr: BaseExpr, Variable {
 
     size_t get() const {
         return index_;
+    }
+
+    ArgBuffer operator[](TypedExpr<size_t> len) const {
+        return {index_, std::move(len)};
     }
 
   private:

--- a/include/kernel_launcher/kernel.h
+++ b/include/kernel_launcher/kernel.h
@@ -43,8 +43,9 @@ struct Kernel {
     /**
      * Launch this kernel onto the given stream with the given arguments.
      */
-    void launch(cudaStream_t stream, Args... args) {
-        std::vector<KernelArg> kargs = {KernelArg::for_scalar<Args>(args)...};
+    void launch(cudaStream_t stream, Args&&... args) {
+        std::vector<KernelArg> kargs = {
+            into_kernel_arg(std::forward<Args>(args))...};
         instance_.launch(stream, kargs);
     }
 

--- a/src/arg.cpp
+++ b/src/arg.cpp
@@ -85,6 +85,28 @@ Value KernelArg::to_value_or_empty() const {
     return {};
 }
 
+KernelArg KernelArg::to_array(size_t nelements) const {
+    if (is_array()) {
+        if (nelements > data_.array.nelements) {
+            throw std::runtime_error(
+                "array of type " + type_.remove_pointer().name()
+                + " cannot be be resized to " + std::to_string(nelements)
+                + " elements, it only has "
+                + std::to_string(data_.array.nelements) + " elements");
+        }
+
+        return {type_, data_.array.ptr, nelements};
+    } else {
+        if (!type_.is_pointer()) {
+            throw std::runtime_error(
+                "argument is not a pointer type and cannot be converted into an array: "
+                + type_.name());
+        }
+
+        return {type_, *(void**)as_void_ptr(), nelements};
+    }
+}
+
 Value KernelArg::to_value() const {
     Value v = to_value_or_empty();
 

--- a/src/arg.cpp
+++ b/src/arg.cpp
@@ -28,6 +28,20 @@ KernelArg::KernelArg(TypeInfo type, void* ptr, size_t nelements) {
 }
 
 KernelArg::KernelArg(const KernelArg& that) : KernelArg() {
+    *this = that;
+}
+
+KernelArg::KernelArg(KernelArg&& that) noexcept : KernelArg() {
+    *this = std::move(that);
+}
+
+KernelArg::~KernelArg() {
+    if (is_scalar() && !is_inline_scalar(type_)) {
+        delete[](char*) data_.large_scalar;
+    }
+}
+
+KernelArg& KernelArg::operator=(const KernelArg& that) {
     type_ = that.type_;
     scalar_ = that.scalar_;
 
@@ -39,18 +53,15 @@ KernelArg::KernelArg(const KernelArg& that) : KernelArg() {
         data_.large_scalar = new char[type_.size()];
         ::memcpy(data_.large_scalar, that.data_.large_scalar, type_.size());
     }
+
+    return *this;
 }
 
-KernelArg::~KernelArg() {
-    if (is_scalar() && !is_inline_scalar(type_)) {
-        delete[](char*) data_.large_scalar;
-    }
-}
-
-KernelArg::KernelArg(KernelArg&& that) noexcept : KernelArg() {
+KernelArg& KernelArg::operator=(KernelArg&& that) noexcept {
     std::swap(this->data_, that.data_);
     std::swap(this->type_, that.type_);
     std::swap(this->scalar_, that.scalar_);
+    return *this;
 }
 
 Value KernelArg::to_value_or_empty() const {

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -135,6 +135,15 @@ KernelBuilder& KernelBuilder::argument_processor(ArgumentsProcessor f) {
     return *this;
 }
 
+KernelBuilder& KernelBuilder::buffer_size(ArgExpr arg, TypedExpr<size_t> len) {
+    return argument_processor([=](auto& args, auto& fallback) {
+        ArgsEval eval {args, fallback};
+        size_t i = arg.get();
+        size_t n = eval(len);
+        args[i] = args[i].to_array(n);
+    });
+}
+
 KernelBuilder& KernelBuilder::block_size(
     TypedExpr<uint32_t> x,
     TypedExpr<uint32_t> y,

--- a/src/builder.cpp
+++ b/src/builder.cpp
@@ -5,7 +5,11 @@
 namespace kernel_launcher {
 
 struct ArgsEval: Eval {
-    ArgsEval(const std::vector<KernelArg>& args) : args_(args) {}
+    explicit ArgsEval(
+        const std::vector<KernelArg>& args,
+        const Eval& fallback) :
+        args_(args),
+        fallback_(fallback) {}
 
     bool lookup(const Variable& v, Value& out) const override {
         if (const auto* that = dynamic_cast<const ArgExpr*>(&v)) {
@@ -20,11 +24,12 @@ struct ArgsEval: Eval {
             }
         }
 
-        return false;
+        return fallback_.lookup(v, out);
     }
 
   private:
     const std::vector<KernelArg>& args_;
+    const Eval& fallback_;
 };
 
 struct DeviceAttrEval: Eval {
@@ -46,9 +51,8 @@ struct DeviceAttrEval: Eval {
 };
 
 struct ProblemSizeEval: Eval {
-    ProblemSizeEval(ProblemSize p, ArgsEval args, const Eval& fallback) :
+    ProblemSizeEval(ProblemSize p, const Eval& fallback) :
         problem_(p),
-        args_(std::move(args)),
         fallback_(fallback) {}
 
     bool lookup(const Variable& v, Value& value) const override {
@@ -59,20 +63,11 @@ struct ProblemSizeEval: Eval {
             }
         }
 
-        if (args_.lookup(v, value)) {
-            return true;
-        }
-
-        if (fallback_.lookup(v, value)) {
-            return true;
-        }
-
-        return false;
+        return fallback_.lookup(v, value);
     }
 
   private:
     ProblemSize problem_;
-    ArgsEval args_;
     const Eval& fallback_;
 };
 
@@ -84,10 +79,11 @@ struct DummyEval: Eval {
 
 void KernelInstance::launch(
     cudaStream_t stream,
+    ProblemSize problem_size,
     const std::vector<KernelArg>& args,
     const Eval& fallback) const {
-    ProblemSize problem_size = problem_extractor_(args);
-    ProblemSizeEval eval {problem_size, args, fallback};
+    ArgsEval args_eval {args, fallback};
+    ProblemSizeEval eval {problem_size, args_eval};
 
     dim3 grid_size = {
         eval(grid_size_[0]),
@@ -111,8 +107,9 @@ void KernelInstance::launch(
 
 void KernelInstance::launch(
     cudaStream_t stream,
+    ProblemSize problem_size,
     const std::vector<KernelArg>& args) const {
-    launch(stream, args, DummyEval {});
+    launch(stream, problem_size, args, DummyEval {});
 }
 
 KernelBuilder::KernelBuilder(
@@ -125,6 +122,17 @@ KernelBuilder::KernelBuilder(
     tuning_key_(kernel_name_) {
     problem_size(0, 0, 0);
     block_size(1, 1, 1);
+}
+
+KernelBuilder& KernelBuilder::argument_processor(ArgumentsProcessor f) {
+    if (!f) {
+        throw std::runtime_error(
+            "null pointer given in "
+            "`KernelBuilder::argument_processor(...)`");
+    }
+
+    args_processors_.push_back(std::move(f));
+    return *this;
 }
 
 KernelBuilder& KernelBuilder::block_size(
@@ -164,19 +172,19 @@ KernelBuilder& KernelBuilder::tuning_key(std::string key) {
     return *this;
 }
 
-KernelBuilder& KernelBuilder::problem_size(ProblemExtractor f) {
+KernelBuilder& KernelBuilder::problem_size(ProblemProcessor f) {
     if (!f) {
         throw std::runtime_error(
-            "provided function cannot be uninitialized in "
-            "KernelBuilder::problem_size");
+            "provided function cannot be null in "
+            "`KernelBuilder::problem_size(...)`");
     }
 
-    problem_extractor_ = std::move(f);
+    problem_processor_ = std::move(f);
     return *this;
 }
 
 KernelBuilder& KernelBuilder::problem_size(ProblemSize p) {
-    problem_extractor_ = [=](const std::vector<KernelArg>& /*unused*/) {
+    problem_processor_ = [=](const std::vector<KernelArg>& /*unused*/) {
         return p;
     };
     return *this;
@@ -186,8 +194,8 @@ KernelBuilder& KernelBuilder::problem_size(
     TypedExpr<uint32_t> x,
     TypedExpr<uint32_t> y,
     TypedExpr<uint32_t> z) {
-    problem_extractor_ = [=](const std::vector<KernelArg>& args) {
-        ArgsEval eval(args);
+    problem_processor_ = [=](const std::vector<KernelArg>& args) {
+        ArgsEval eval(args, DummyEval {});
         return ProblemSize {eval(x), eval(y), eval(z)};
     };
 
@@ -258,15 +266,27 @@ KernelDef KernelBuilder::build(
     return def;
 }
 
-ProblemSize
-KernelBuilder::extract_problem_size(const std::vector<KernelArg>& args) const {
-    if (!problem_extractor_) {
+ProblemProcessor KernelBuilder::problem_processor() const {
+    if (!problem_processor_) {
         throw std::runtime_error(
             "no problem size configured. Please call "
             "`KernelBuilder::problem_size()` first.");
     }
 
-    return problem_extractor_(args);
+    ProblemProcessor f = problem_processor_;
+    std::vector<ArgumentsProcessor> procs = args_processors_;
+
+    if (procs.empty()) {
+        return f;
+    }
+
+    return [=](auto& args) {
+        for (const auto& proc : procs) {
+            proc(args, DummyEval {});
+        }
+
+        return f(args);
+    };
 }
 
 static const TunableParam*
@@ -408,12 +428,11 @@ KernelInstance KernelBuilder::compile(
 
     TypedExpr<uint32_t> shared_mem = shared_mem_.resolve(eval);
 
-    return KernelInstance(
+    return {
         std::move(module),
-        problem_extractor_,
         std::move(block_size),
         std::move(grid_size),
-        shared_mem);
+        shared_mem};
 }
 
 }  // namespace kernel_launcher

--- a/tests/arg.cpp
+++ b/tests/arg.cpp
@@ -1,0 +1,112 @@
+#include "catch.hpp"
+#include "kernel_launcher/kernel.h"
+#include "test_utils.h"
+
+using namespace kernel_launcher;
+
+TEST_CASE("test KernelArg") {
+    SECTION("scalar int") {
+        KernelArg v = into_kernel_arg(5);
+        CHECK(v.type() == type_of<int>());
+        CHECK(
+            v.to_bytes() == std::vector<uint8_t> {5, 0, 0, 0});  // Assuming LE?
+        CHECK(v.is_array() == false);
+        CHECK(v.is_scalar() == true);
+
+        int result;
+        ::memcpy(&result, v.as_void_ptr(), sizeof(int));
+        CHECK(result == 5);
+
+        CHECK(v.to<int>() == 5);
+        CHECK(v.to_value() == Value(5));
+        CHECK_THROWS(v.to<double>());
+    }
+
+    SECTION("scalar point3") {
+        point3 input = {1, 2, 3};
+
+        KernelArg v = into_kernel_arg(input);
+        CHECK(v.type() == type_of<point3>());
+        CHECK(
+            v.to_bytes()
+            == std::vector<uint8_t> {
+                1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
+                0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0});  // Assuming LE?
+        CHECK(v.is_array() == false);
+        CHECK(v.is_scalar() == true);
+
+        point3 result;
+        ::memcpy(&result, v.as_void_ptr(), sizeof(point3));
+        CHECK(result == input);
+
+        CHECK(v.to<point3>() == input);
+        CHECK_THROWS(v.to<double>());
+    }
+
+    SECTION("array int*") {
+        std::vector<int> input = {1, 2, 3};
+
+        KernelArg v = KernelArg::for_array(input.data(), input.size());
+        CHECK(v.type() == type_of<int*>());
+        //        // This only works if cuda is enabled :-(
+        //        CHECK(
+        //            v.to_bytes()
+        //            == std::vector<
+        //                uint8_t> {1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0});  // Assuming LE?
+        CHECK(v.is_array() == true);
+        CHECK(v.is_scalar() == false);
+        CHECK(*(int**)(v.as_void_ptr()) == input.data());
+
+        CHECK(v.to<int*>() == input.data());
+        CHECK(v.to<const int*>() == input.data());
+        CHECK_THROWS(v.to<double>());
+    }
+
+    SECTION("array const int*") {
+        std::vector<int> input = {1, 2, 3};
+
+        KernelArg v =
+            KernelArg::for_array<const int>(input.data(), input.size());
+        CHECK(v.type() == type_of<const int*>());
+        CHECK(v.is_array() == true);
+        CHECK(v.is_scalar() == false);
+        CHECK(*(const int**)(v.as_void_ptr()) == input.data());
+
+        CHECK_THROWS(v.to<int*>() == input.data());
+        CHECK(v.to<const int*>() == input.data());
+        CHECK_THROWS(v.to<double>());
+    }
+
+    SECTION("to_value") {
+        CHECK(KernelArg::for_scalar<signed char>(13).to_value() == 13);
+        CHECK(KernelArg::for_scalar<unsigned char>(14).to_value() == 14);
+        CHECK(KernelArg::for_scalar<char>(15).to_value() == 15);
+        CHECK(KernelArg::for_scalar<int>(16).to_value() == 16);
+        CHECK(KernelArg::for_scalar<double>(17).to_value() == 17.0);
+
+        // `const` should not matter
+        CHECK(KernelArg::for_scalar<const int>(18).to_value() == 18);
+
+        // These should fail
+        CHECK_THROWS(KernelArg::for_scalar<point3>({1, 2, 3}).to_value());
+        CHECK_THROWS(KernelArg::for_array<int>(nullptr, 2).to_value());
+    }
+
+    SECTION("to_array") {
+        std::vector<char> input = {1, 2, 3};
+
+        // non-pointer types can never be converted to arrays
+        CHECK_THROWS(KernelArg::for_scalar(123).to_array(0));
+        CHECK_THROWS(KernelArg::for_scalar(123).to_array(1));
+
+        // pointer types can be converted to arrays
+        CHECK_NOTHROW(KernelArg::for_scalar(input.data()).to_array(0));
+        CHECK_NOTHROW(KernelArg::for_scalar(input.data()).to_array(3));
+
+        // arrays can only be converted to arrays which are smaller
+        CHECK_NOTHROW(
+            KernelArg::for_array(input.data(), input.size()).to_array(2));
+        CHECK_THROWS(
+            KernelArg::for_array(input.data(), input.size()).to_array(5));
+    }
+}

--- a/tests/arg.cpp
+++ b/tests/arg.cpp
@@ -46,7 +46,7 @@ TEST_CASE("test KernelArg") {
     SECTION("array int*") {
         std::vector<int> input = {1, 2, 3};
 
-        KernelArg v = KernelArg::for_array(input.data(), input.size());
+        KernelArg v = KernelArg::from_array(input.data(), input.size());
         CHECK(v.type() == type_of<int*>());
         //        // This only works if cuda is enabled :-(
         //        CHECK(
@@ -66,7 +66,7 @@ TEST_CASE("test KernelArg") {
         std::vector<int> input = {1, 2, 3};
 
         KernelArg v =
-            KernelArg::for_array<const int>(input.data(), input.size());
+            KernelArg::from_array<const int>(input.data(), input.size());
         CHECK(v.type() == type_of<const int*>());
         CHECK(v.is_array() == true);
         CHECK(v.is_scalar() == false);
@@ -78,35 +78,35 @@ TEST_CASE("test KernelArg") {
     }
 
     SECTION("to_value") {
-        CHECK(KernelArg::for_scalar<signed char>(13).to_value() == 13);
-        CHECK(KernelArg::for_scalar<unsigned char>(14).to_value() == 14);
-        CHECK(KernelArg::for_scalar<char>(15).to_value() == 15);
-        CHECK(KernelArg::for_scalar<int>(16).to_value() == 16);
-        CHECK(KernelArg::for_scalar<double>(17).to_value() == 17.0);
+        CHECK(KernelArg::from_scalar<signed char>(13).to_value() == 13);
+        CHECK(KernelArg::from_scalar<unsigned char>(14).to_value() == 14);
+        CHECK(KernelArg::from_scalar<char>(15).to_value() == 15);
+        CHECK(KernelArg::from_scalar<int>(16).to_value() == 16);
+        CHECK(KernelArg::from_scalar<double>(17).to_value() == 17.0);
 
         // `const` should not matter
-        CHECK(KernelArg::for_scalar<const int>(18).to_value() == 18);
+        CHECK(KernelArg::from_scalar<const int>(18).to_value() == 18);
 
         // These should fail
-        CHECK_THROWS(KernelArg::for_scalar<point3>({1, 2, 3}).to_value());
-        CHECK_THROWS(KernelArg::for_array<int>(nullptr, 2).to_value());
+        CHECK_THROWS(KernelArg::from_scalar<point3>({1, 2, 3}).to_value());
+        CHECK_THROWS(KernelArg::from_array<int>(nullptr, 2).to_value());
     }
 
     SECTION("to_array") {
         std::vector<char> input = {1, 2, 3};
 
         // non-pointer types can never be converted to arrays
-        CHECK_THROWS(KernelArg::for_scalar(123).to_array(0));
-        CHECK_THROWS(KernelArg::for_scalar(123).to_array(1));
+        CHECK_THROWS(KernelArg::from_scalar(123).to_array(0));
+        CHECK_THROWS(KernelArg::from_scalar(123).to_array(1));
 
         // pointer types can be converted to arrays
-        CHECK_NOTHROW(KernelArg::for_scalar(input.data()).to_array(0));
-        CHECK_NOTHROW(KernelArg::for_scalar(input.data()).to_array(3));
+        CHECK_NOTHROW(KernelArg::from_scalar(input.data()).to_array(0));
+        CHECK_NOTHROW(KernelArg::from_scalar(input.data()).to_array(3));
 
         // arrays can only be converted to arrays which are smaller
         CHECK_NOTHROW(
-            KernelArg::for_array(input.data(), input.size()).to_array(2));
+            KernelArg::from_array(input.data(), input.size()).to_array(2));
         CHECK_THROWS(
-            KernelArg::for_array(input.data(), input.size()).to_array(5));
+            KernelArg::from_array(input.data(), input.size()).to_array(5));
     }
 }

--- a/tests/builder.cpp
+++ b/tests/builder.cpp
@@ -1,0 +1,54 @@
+#include "kernel_launcher/builder.h"
+
+#include "catch.hpp"
+#include "test_utils.h"
+
+using namespace kernel_launcher;
+
+TEST_CASE("KernelBuilder") {
+    std::array<int, 5> data = {1, 2, 3, 4, 5};
+    KernelBuilder builder("nothing", "stdin");
+    std::vector<KernelArg> args = {
+        KernelArg::from_scalar(100),
+        KernelArg::from_scalar(200),
+        KernelArg::from_scalar(&data[0])};
+
+    SECTION("problem_size static") {
+        builder.problem_size(ProblemSize(100, 200));
+        auto f = builder.problem_processor();
+        CHECK(f(args) == ProblemSize {100, 200});
+    }
+
+    SECTION("problem_size expression") {
+        builder.problem_size(arg0, arg1);
+        auto f = builder.problem_processor();
+        CHECK(f(args) == ProblemSize {100, 200});
+    }
+
+    SECTION("problem_size function") {
+        builder.problem_size(ProblemProcessor([](auto& args) {
+            return ProblemSize {
+                args[0].to_value().template to<uint32_t>(),
+                args[1].to_value().template to<uint32_t>()};
+        }));
+
+        auto f = builder.problem_processor();
+        CHECK(f(args) == ProblemSize {100, 200});
+    }
+
+    SECTION("buffer_size") {
+        builder.problem_size(arg0, arg1);
+        builder.buffer_size(arg2, arg0);
+        auto f = builder.problem_processor();
+        CHECK(f(args) == ProblemSize {100, 200});
+        CHECK(args[2].is_array());
+    }
+
+    SECTION("buffers") {
+        builder.problem_size(arg0, arg1);
+        builder.buffers(arg2[arg0]);
+        auto f = builder.problem_processor();
+        CHECK(f(args) == ProblemSize {100, 200});
+        CHECK(args[2].is_array());
+    }
+}

--- a/tests/export.cpp
+++ b/tests/export.cpp
@@ -80,14 +80,14 @@ TEST_CASE("test export_tuning_file", "[CUDA]") {
              type_of<float*>(),
              type_of<const float*>(),
              type_of<const float*>()},
-            {KernelArg::for_scalar(int(n)).to_bytes(),
-             KernelArg::for_array(c.data(), c.size()).to_bytes(),
-             KernelArg::for_array(a.data(), a.size()).to_bytes(),
-             KernelArg::for_array(b.data(), b.size()).to_bytes()},
-            {KernelArg::for_scalar(int(n)).to_bytes(),
-             KernelArg::for_array(c_ref.data(), c_ref.size()).to_bytes(),
-             KernelArg::for_array(a.data(), a.size()).to_bytes(),
-             KernelArg::for_array(b.data(), b.size()).to_bytes()});
+            {KernelArg::from_scalar(int(n)).to_bytes(),
+             KernelArg::from_array(c.data(), c.size()).to_bytes(),
+             KernelArg::from_array(a.data(), a.size()).to_bytes(),
+             KernelArg::from_array(b.data(), b.size()).to_bytes()},
+            {KernelArg::from_scalar(int(n)).to_bytes(),
+             KernelArg::from_array(c_ref.data(), c_ref.size()).to_bytes(),
+             KernelArg::from_array(a.data(), a.size()).to_bytes(),
+             KernelArg::from_array(b.data(), b.size()).to_bytes()});
 
         compare_exports("vector_add_key_1024", tmp_dir, assets_dir);
     }
@@ -132,14 +132,14 @@ TEST_CASE("test export_tuning_file", "[CUDA]") {
              type_of<float*>(),
              type_of<const float*>(),
              type_of<const float*>()},
-            {KernelArg::for_scalar(int(n)).to_bytes(),
-             KernelArg::for_array(c.data(), c.size()).to_bytes(),
-             KernelArg::for_array(a.data(), a.size()).to_bytes(),
-             KernelArg::for_array(b.data(), b.size()).to_bytes()},
-            {KernelArg::for_scalar(int(n)).to_bytes(),
-             KernelArg::for_array(c_ref.data(), c_ref.size()).to_bytes(),
-             KernelArg::for_array(a.data(), a.size()).to_bytes(),
-             KernelArg::for_array(b.data(), b.size()).to_bytes()});
+            {KernelArg::from_scalar(int(n)).to_bytes(),
+             KernelArg::from_array(c.data(), c.size()).to_bytes(),
+             KernelArg::from_array(a.data(), a.size()).to_bytes(),
+             KernelArg::from_array(b.data(), b.size()).to_bytes()},
+            {KernelArg::from_scalar(int(n)).to_bytes(),
+             KernelArg::from_array(c_ref.data(), c_ref.size()).to_bytes(),
+             KernelArg::from_array(a.data(), a.size()).to_bytes(),
+             KernelArg::from_array(b.data(), b.size()).to_bytes()});
 
         compare_exports("matmul_key_1024x1024", tmp_dir, assets_dir);
     }

--- a/tests/kernel.cpp
+++ b/tests/kernel.cpp
@@ -6,7 +6,7 @@
 
 using namespace kernel_launcher;
 
-TEST_CASE("KernelBuilder", "[CUDA]") {
+TEST_CASE("KernelBuilder compilation", "[CUDA]") {
     CUcontext ctx;
     KERNEL_LAUNCHER_CUDA_CHECK(cuInit(0));
     KERNEL_LAUNCHER_CUDA_CHECK(cuCtxCreate(&ctx, 0, 0));

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -19,7 +19,7 @@ namespace kernel_launcher {
 template<>
 struct IntoKernelArg<point3> {
     static KernelArg convert(point3 value) {
-        return KernelArg::for_scalar<point3>(value);
+        return KernelArg::from_scalar<point3>(value);
     }
 };
 }  // namespace kernel_launcher

--- a/tests/test_utils.h
+++ b/tests/test_utils.h
@@ -5,6 +5,25 @@
 
 #include "kernel_launcher/kernel.h"
 
+struct point3 {
+    unsigned long long x;
+    unsigned long long y;
+    unsigned long long z;
+
+    bool operator==(point3 v) const {
+        return x == v.x && y == v.y && z == v.z;
+    }
+};
+
+namespace kernel_launcher {
+template<>
+struct IntoKernelArg<point3> {
+    static KernelArg convert(point3 value) {
+        return KernelArg::for_scalar<point3>(value);
+    }
+};
+}  // namespace kernel_launcher
+
 inline std::string assets_directory() {
     std::string assets_dir = __FILE__;
     assets_dir = assets_dir.substr(0, assets_dir.rfind('/'));

--- a/tests/wisdom.cpp
+++ b/tests/wisdom.cpp
@@ -4,25 +4,6 @@
 
 using namespace kernel_launcher;
 
-struct point3 {
-    unsigned long long x;
-    unsigned long long y;
-    unsigned long long z;
-
-    bool operator==(point3 v) const {
-        return x == v.x && y == v.y && z == v.z;
-    }
-};
-
-namespace kernel_launcher {
-template<>
-struct IntoKernelArg<point3> {
-    static KernelArg convert(point3 value) {
-        return KernelArg::for_scalar<point3>(value);
-    }
-};
-}  // namespace kernel_launcher
-
 TEST_CASE("test load_best_config") {
     std::string wisdom_dir = assets_directory();
     ConfigSpace space;
@@ -186,95 +167,6 @@ TEST_CASE("test process_wisdom_file") {
 
         CHECK(lineno == 5);
         CHECK(success);
-    }
-}
-
-TEST_CASE("test KernelArg") {
-    SECTION("scalar int") {
-        KernelArg v = into_kernel_arg(5);
-        CHECK(v.type() == type_of<int>());
-        CHECK(
-            v.to_bytes() == std::vector<uint8_t> {5, 0, 0, 0});  // Assuming LE?
-        CHECK(v.is_array() == false);
-        CHECK(v.is_scalar() == true);
-
-        int result;
-        ::memcpy(&result, v.as_void_ptr(), sizeof(int));
-        CHECK(result == 5);
-
-        CHECK(v.to<int>() == 5);
-        CHECK(v.to_value() == Value(5));
-        CHECK_THROWS(v.to<double>());
-    }
-
-    SECTION("scalar point3") {
-        point3 input = {1, 2, 3};
-
-        KernelArg v = into_kernel_arg(input);
-        CHECK(v.type() == type_of<point3>());
-        CHECK(
-            v.to_bytes()
-            == std::vector<uint8_t> {
-                1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0,
-                0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0});  // Assuming LE?
-        CHECK(v.is_array() == false);
-        CHECK(v.is_scalar() == true);
-
-        point3 result;
-        ::memcpy(&result, v.as_void_ptr(), sizeof(point3));
-        CHECK(result == input);
-
-        CHECK(v.to<point3>() == input);
-        CHECK_THROWS(v.to<double>());
-    }
-
-    SECTION("array int*") {
-        std::vector<int> input = {1, 2, 3};
-
-        KernelArg v = KernelArg::for_array(input.data(), input.size());
-        CHECK(v.type() == type_of<int*>());
-        //        // This only works if cuda is enabled :-(
-        //        CHECK(
-        //            v.to_bytes()
-        //            == std::vector<
-        //                uint8_t> {1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0});  // Assuming LE?
-        CHECK(v.is_array() == true);
-        CHECK(v.is_scalar() == false);
-        CHECK(*(int**)(v.as_void_ptr()) == input.data());
-
-        CHECK(v.to<int*>() == input.data());
-        CHECK(v.to<const int*>() == input.data());
-        CHECK_THROWS(v.to<double>());
-    }
-
-    SECTION("array const int*") {
-        std::vector<int> input = {1, 2, 3};
-
-        KernelArg v =
-            KernelArg::for_array<const int>(input.data(), input.size());
-        CHECK(v.type() == type_of<const int*>());
-        CHECK(v.is_array() == true);
-        CHECK(v.is_scalar() == false);
-        CHECK(*(const int**)(v.as_void_ptr()) == input.data());
-
-        CHECK_THROWS(v.to<int*>() == input.data());
-        CHECK(v.to<const int*>() == input.data());
-        CHECK_THROWS(v.to<double>());
-    }
-
-    SECTION("to_value") {
-        CHECK(KernelArg::for_scalar<signed char>(13).to_value() == 13);
-        CHECK(KernelArg::for_scalar<unsigned char>(14).to_value() == 14);
-        CHECK(KernelArg::for_scalar<char>(15).to_value() == 15);
-        CHECK(KernelArg::for_scalar<int>(16).to_value() == 16);
-        CHECK(KernelArg::for_scalar<double>(17).to_value() == 17.0);
-
-        // `const` should not matter
-        CHECK(KernelArg::for_scalar<const int>(18).to_value() == 18);
-
-        // These should fail
-        CHECK_THROWS(KernelArg::for_scalar<point3>({1, 2, 3}).to_value());
-        CHECK_THROWS(KernelArg::for_array<int>(nullptr, 2).to_value());
     }
 }
 


### PR DESCRIPTION
This PR adds support for specifying the sizes of buffers while defining a kernel. More concretely, it adds the method `KernelBuilder::buffer_size(int i, Expr n)` that allows one to specify that the `i`-th argument is a buffer containing `n` elements. This means that the kernel can be captured even when called with raw pointers, since it is possible to determine the buffer length for exporting the data.