### PR TITLE
Missing include to fix `unknown type 'uint32_t'`, `uint64_t`, etc.

### DIFF
--- a/include/kernel_launcher/utils.h
+++ b/include/kernel_launcher/utils.h
@@ -11,6 +11,7 @@
 #include <type_traits>
 #include <typeindex>
 #include <vector>
+#include <stdint.h>
 
 namespace kernel_launcher {
 


### PR DESCRIPTION
Without this include, I'm getting a bunch of errors like:

```
/home/bart/meteo/models/microhh/external/kernel_launcher/include/kernel_launcher/utils.h:348:5: error: unknown type name 'uint32_t' [clang-diagnostic-error]
    uint32_t z;
    ^
/home/bart/meteo/models/microhh/external/kernel_launcher/include/kernel_launcher/utils.h:412:16: error: unknown type name 'uint64_t' [clang-diagnostic-error]
using hash_t = uint64_t;
               ^
/home/bart/meteo/models/microhh/external/kernel_launcher/include/kernel_launcher/utils.h:414:1: error: unknown type name 'hash_t' [clang-diagnostic-error]
hash_t hash_string(const char* buffer, size_t num_bytes);
^
```
